### PR TITLE
Add command to connect user account to MS Teams

### DIFF
--- a/server/authorization.go
+++ b/server/authorization.go
@@ -21,7 +21,7 @@ func (ae *authError) Error() string {
 
 var oAuthMessage string = "[Click here to link your Microsoft account.](%s/plugins/" + manifest.Id + "/oauth2/connect?channelID=%s)"
 
-func (p *Plugin) authenticateAndFetchUser(userID, userEmail, channelID string) (*msgraph.User, *authError) {
+func (p *Plugin) authenticateAndFetchUser(userID, channelID string) (*msgraph.User, *authError) {
 	var user *msgraph.User
 	var err error
 

--- a/server/command.go
+++ b/server/command.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	commandHelp = `* |/mstmeetings start| - Start an MS Teams meeting.
-* |/mstmeetings disconnect| - Disconnect from Mattermost
-* |/mstmeetings connect| - Connect to MS Teams meeting`
+* |/mstmeetings connect| - Connect to MS Teams meeting
+* |/mstmeetings disconnect| - Disconnect from Mattermost`
 	tooManyParametersText = "Too many parameters."
 )
 

--- a/server/command.go
+++ b/server/command.go
@@ -44,7 +44,7 @@ func (p *Plugin) postCommandResponse(args *model.CommandArgs, text string) {
 	_ = p.API.SendEphemeralPost(args.UserId, post)
 }
 
-func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (string, error) {
+func (p *Plugin) executeCommand(_ *plugin.Context, args *model.CommandArgs) (string, error) {
 	split := strings.Fields(args.Command)
 	command := split[0]
 	action := ""
@@ -56,7 +56,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 	if len(split) > 1 {
 		action = split[1]
 	} else {
-		return p.handleHelp(split, args)
+		return p.handleHelp()
 	}
 
 	switch action {
@@ -67,7 +67,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 	case "disconnect":
 		return p.handleDisconnect(split[1:], args)
 	case "help":
-		return p.handleHelp(split[1:], args)
+		return p.handleHelp()
 	}
 
 	return fmt.Sprintf("Unknown action `%v`.\n%s", action, p.getHelpText()), nil
@@ -77,7 +77,7 @@ func (p *Plugin) getHelpText() string {
 	return "###### Mattermost MS Teams Meetings Plugin - Slash Command Help\n" + strings.ReplaceAll(commandHelp, "|", "`")
 }
 
-func (p *Plugin) handleHelp(args []string, extra *model.CommandArgs) (string, error) {
+func (p *Plugin) handleHelp() (string, error) {
 	return p.getHelpText(), nil
 }
 
@@ -106,7 +106,7 @@ func (p *Plugin) handleStart(args []string, extra *model.CommandArgs) (string, e
 		return "", nil
 	}
 
-	_, authErr := p.authenticateAndFetchUser(userID, user.Email, extra.ChannelId)
+	_, authErr := p.authenticateAndFetchUser(userID, extra.ChannelId)
 	if authErr != nil {
 		return authErr.Message, authErr.Err
 	}
@@ -125,12 +125,7 @@ func (p *Plugin) handleConnect(args []string, extra *model.CommandArgs) (string,
 		return tooManyParametersText, nil
 	}
 
-	user, appErr := p.API.GetUser(extra.UserId)
-	if appErr != nil {
-		return "Cannot get user.", errors.Wrap(appErr, "cannot get user")
-	}
-
-	msUser, authErr := p.authenticateAndFetchUser(user.Id, user.Email, extra.ChannelId)
+	msUser, authErr := p.authenticateAndFetchUser(extra.UserId, extra.ChannelId)
 	if authErr != nil {
 		return authErr.Message, authErr.Err
 	}

--- a/server/http.go
+++ b/server/http.go
@@ -21,7 +21,7 @@ const (
 	msteamsProviderName = "Microsoft Teams Meetings"
 )
 
-func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 	if err := config.IsValid(); err != nil {
 		http.Error(w, "This plugin is not configured.", http.StatusNotImplemented)
@@ -247,7 +247,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	_, authErr := p.authenticateAndFetchUser(userID, user.Email, req.ChannelID)
+	_, authErr := p.authenticateAndFetchUser(userID, req.ChannelID)
 	if authErr != nil {
 		if _, err = w.Write([]byte(`{"meeting_url": ""}`)); err != nil {
 			p.API.LogWarn("failed to write response", "error", err.Error())

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -25,8 +25,6 @@ const (
 type Plugin struct {
 	plugin.MattermostPlugin
 
-	client *pluginapi.Client
-
 	// botUserID of the created bot account.
 	botUserID string
 


### PR DESCRIPTION
#### Summary
- Added command to connect user account to MS Teams
- Updated help command

#### Ticket Link
Fixes #66 

#### What to test?
- Run the slash command `/mstmeetings connect`
- Check if user is able to connect by clicking on the provided link
- Run the slash command `/mstmeetings connect` again after connecting, the user should get the ephemeral post `User already connected to MS Teams Meetings`

#### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks
