### PR TITLE
MM-59972 Escape manifest when encoding in url

### DIFF
--- a/server/authorization.go
+++ b/server/authorization.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	msgraph "github.com/yaegashi/msgraph.go/beta"
 	"golang.org/x/oauth2"
@@ -19,7 +20,7 @@ func (ae *authError) Error() string {
 	return string(errorString)
 }
 
-var oAuthMessage string = "[Click here to link your Microsoft account.](%s/plugins/" + manifest.Id + "/oauth2/connect?channelID=%s)"
+var oAuthMessage string = "[Click here to link your Microsoft account.](%s/plugins/" + url.PathEscape(manifest.Id) + "/oauth2/connect?channelID=%s)"
 
 func (p *Plugin) authenticateAndFetchUser(userID, channelID string) (*msgraph.User, *authError) {
 	var user *msgraph.User


### PR DESCRIPTION
URL generation in mattermost-plugin-msteams-meetings/server/authorization.go uses string interpolation/concatenation without safely escaping strings
	
This PR fixes this by encoding URL params in several places:

1. var oAuthMessage string = "[Click here to link your Microsoft account.](%s/plugins/" + manifest.Id + "/oauth2/connect?channelID=%s)"
2.  redirectURL := fmt.Sprintf("%s/plugins/%s/oauth2/complete", siteURL, manifest.Id)