### PR TITLE
Bump version number to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Start and join voice calls, video calls, and use screen sharing with your team m
 
 ### Requirements
 
-Mattermost Server v5.26+ is required.
+Mattermost Server v8.1+ is required.
 
 ### Installation
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,12 @@
 {
     "id": "com.mattermost.msteamsmeetings",
     "name": "MS Teams Meetings",
-    "description": "MS Teams Meetings audio and video conferencing plugin for Mattermost 5.2+.",
+    "description": "MS Teams Meetings audio and video conferencing plugin for Mattermost 8.1+.",
     "homepage_url": "https://mattermost.com/pl/mattermost-plugin-msteams-meetings",
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases/tag/v2.1.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases/tag/v2.2.0",
     "icon_path": "assets/profile.svg",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "min_server_version": "8.1.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -6,5 +6,5 @@ import "github.com/mattermost/mattermost/server/public/model"
 
 var manifest = model.Manifest{
 	Id:      "com.mattermost.msteamsmeetings",
-	Version: "2.1.0",
+	Version: "2.2.0",
 }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27934,6 +27934,7 @@
     },
     "redux-offline": {
       "version": "git+ssh://git@github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
+      "integrity": "sha512-srmJ1vWm8ZQTYflZCf7oUs3WBX83GyCIzsFUpwxUg2wcDHngSHjjShRTCgmkciPkVmM4aJ33i9baYS9jRC+zLA==",
       "from": "redux-offline@git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
       "requires": {
         "@react-native-community/netinfo": "^4.1.3",


### PR DESCRIPTION
Bumps plugin version number in preparation for new release.  v2.1.0 --> v2.2.0

Also bumps docs for minimum server version to 8.1+